### PR TITLE
fix bugs and enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - composer install
   
 script:
-  - vendor/bin/phpunit --coverage-clover=coverage.xml --configuration phpunit.xml
+  - vendor/bin/phpunit --coverage-clover=coverage.xml
   
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,22 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0"
+        "php": ">=7.0.0",
+        "ext-imap": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "ext-imap": "*",
+        "ext-mbstring": "*"
     },
     "autoload": {
         "psr-4": {
             "IvoPetkov\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "IvoPetkov\\EmailParser\\": "tests/"
         }
     }
 }

--- a/src/EmailParser.php
+++ b/src/EmailParser.php
@@ -22,65 +22,29 @@ class EmailParser
      */
     public function parse(string $email): array
     {
-
         $result = [];
-        $parts = explode("\r\n\r\n", $email, 2);
+        $parts = explode(PHP_EOL.PHP_EOL, $email, 2);
         $headers = $this->parseHeaders($parts[0]);
-        $result['deliveryDate'] = strtotime($this->getHeaderValue($headers, 'Delivery-date'));
-        $result['returnPath'] = $this->parseEmailAddress($this->getHeaderValue($headers, 'Return-path'))['email'];
+        file_put_contents('dump_header.txt', serialize($headers));
+        $result['returnPath'] = $this->getHeaderValue($headers, 'Return-Path');
         $priority = substr($this->getHeaderValue($headers, 'X-Priority'), 0, 1);
         $result['priority'] = strlen($priority) > 0 ? (int) $priority : null;
+        $result['deliveryDate'] = strtotime($this->getHeaderValue($headers, 'Delivery-Date'));
         $result['date'] = strtotime($this->getHeaderValue($headers, 'Date'));
-        $result['subject'] = $this->decodeMIMEEncodedText($this->getHeaderValue($headers, 'Subject'));
-        $result['to'] = $this->parseEmailAddresses($this->getHeaderValue($headers, 'To'));
-        $result['from'] = $this->parseEmailAddress($this->getHeaderValue($headers, 'From'));
-        $result['replyTo'] = $this->parseEmailAddresses($this->getHeaderValue($headers, 'Reply-To'));
-        $result['cc'] = $this->parseEmailAddresses($this->getHeaderValue($headers, 'Cc'));
-        $result['bcc'] = $this->parseEmailAddresses($this->getHeaderValue($headers, 'Bcc'));
+        $result['subject'] = $this->getHeaderValue($headers, 'Subject');
+        $result['to'] = $this->parseEmailAddress($this->getHeaderValue($headers, 'toaddress'));
+        $result['from'] = $this->parseEmailAddresses($this->getHeaderValues($headers, 'from'));
+        $result['replyTo'] = $this->parseEmailAddresses($this->getHeaderValues($headers, 'Reply-To'));
+        $result['sender'] = $this->parseEmailAddresses($this->getHeaderValues($headers, 'sender'));
+        $result['cc'] = $this->parseEmailAddress($this->getHeaderValue($headers, 'Cc'));
+        $result['bcc'] = $this->parseEmailAddress($this->getHeaderValue($headers, 'Bcc'));
         $result['content'] = [];
         $result['attachments'] = [];
         $result['embeds'] = [];
         $result['headers'] = [];
-        foreach ($headers as $header) {
-            $result['headers'][] = ['name' => $header[0], 'value' => $header[1]];
+        foreach ($headers as $header => $value) {
+            $result['headers'][] = ['name' => $header, 'value' => $value];
         }
-
-        $bodyParts = $this->getBodyParts($email);
-        foreach ($bodyParts as $bodyPart) {
-            $contentDispositionData = $this->getHeaderValueAndOptions($bodyPart[0], 'Content-Disposition');
-            $contentDisposition = strtolower($contentDispositionData[0]);
-            $contentTypeData = $this->getHeaderValueAndOptions($bodyPart[0], 'Content-Type');
-            $mimeType = strlen($contentTypeData[0]) > 0 ? strtolower($contentTypeData[0]) : null;
-            if ($bodyPart[2] === 1 && ($contentDisposition === 'inline' || $contentDisposition === 'attachment')) {
-                if (isset($contentDispositionData[1]['filename'])) {
-                    $contentDisposition = 'attachment';
-                }
-                $attachmentData = [];
-                $attachmentData['mimeType'] = $mimeType;
-                $attachmentData['name'] = isset($contentTypeData[1]['name']) ? $this->decodeMIMEEncodedText($contentTypeData[1]['name']) : null;
-                if ($contentDisposition === 'inline') {
-                    $id = trim($this->getHeaderValue($bodyPart[0], 'Content-ID'), '<>');
-                    $attachmentData['id'] = strlen($id) > 0 ? $id : null;
-                }
-                $attachmentData['content'] = $this->decodeBodyPart($bodyPart[0], $bodyPart[1]);
-                $result[$contentDisposition === 'inline' ? 'embeds' : 'attachments'][] = $attachmentData;
-            } else {
-                $contentData = [];
-                $contentData['mimeType'] = $mimeType;
-                $contentData['encoding'] = isset($contentTypeData[1]['charset']) ? strtolower(trim($contentTypeData[1]['charset'])) : null;
-                $contentData['content'] = $this->decodeBodyPart($bodyPart[0], $bodyPart[1]);
-                $result['content'][] = $contentData;
-            }
-        }
-//        if (!empty($inlineAttachments) && strlen($result['html']) > 0) {
-//            foreach ($inlineAttachments as $inlineAttachment) {
-//                if (strlen($inlineAttachment['id']) > 0 && strlen($inlineAttachment['contentType']) > 0) {
-//                    if (strpos($result['html'], 'cid:' . $inlineAttachment['id'])) {
-//                        $result['html'] = str_replace('cid:' . $inlineAttachment['id'], 'data:' . $inlineAttachment['contentType'] . ';base64,' . $inlineAttachment['base64Content'], $result['html']);
-//                    }
-//                }
-//            }
-//        }
 
         return $result;
     }
@@ -109,25 +73,8 @@ class EmailParser
      */
     private function parseHeaders(string $headers): array
     {
-        $lines = explode("\r\n", trim($headers));
-        $temp = [];
-        foreach ($lines as $line) {
-            if (preg_match('/^[a-zA-Z0-9]/', $line) === 1) {
-                $temp[] = trim($line);
-            } else {
-                if (sizeof($temp) > 0) {
-                    $temp[sizeof($temp) - 1] .= ' ' . trim($line);
-                } else {
-                    $temp[] = trim($line);
-                }
-            }
-        }
-        $result = [];
-        foreach ($temp as $line) {
-            $parts = explode(':', $line, 2);
-            $result[] = [trim($parts[0]), isset($parts[1]) ? trim($parts[1]) : ''];
-        }
-        return $result;
+        $result = \imap_rfc822_parse_headers($headers);
+        return (array)$result;
     }
 
     /**
@@ -139,12 +86,8 @@ class EmailParser
     private function getHeaderValue(array $headers, string $name): string
     {
         $name = strtolower($name);
-        foreach ($headers as $header) {
-            if (strtolower($header[0]) === $name) {
-                return $header[1];
-            }
-        }
-        return '';
+        $name = str_replace('-', '_', $name);
+        return isset($headers[$name]) ? $headers[$name] : '';
     }
 
     /**
@@ -153,30 +96,11 @@ class EmailParser
      * @param string $name
      * @return array
      */
-    private function getHeaderValueAndOptions(array $headers, string $name): array
+    private function getHeaderValues(array $headers, string $name): array
     {
         $name = strtolower($name);
-        foreach ($headers as $header) {
-            if (strtolower($header[0]) === $name) {
-                $parts = explode(';', trim($header[1]));
-                $value = trim($parts[0]);
-                $options = [];
-                unset($parts[0]);
-                if (!empty($parts)) {
-                    foreach ($parts as $part) {
-                        $part = trim($part);
-                        if (isset($part{0})) {
-                            $optionParts = explode('=', $part, 2);
-                            if (sizeof($optionParts) === 2) {
-                                $options[strtolower(trim($optionParts[0]))] = trim(trim(trim($optionParts[1]), '"\''));
-                            }
-                        }
-                    }
-                }
-                return [$value, $options];
-            }
-        }
-        return ['', []];
+        $name = str_replace('-', '_', $name);
+        return isset($headers[$name]) ? $headers[$name] : '';
     }
 
     /**
@@ -186,27 +110,52 @@ class EmailParser
      */
     private function parseEmailAddress(string $address): array
     {
-        $matches = [];
-        preg_match("/(.*)\<(.*)\>/", $address, $matches);
-        if (sizeof($matches) === 3) {
-            return ['email' => strtolower(trim($matches[2])), 'name' => trim($this->decodeMIMEEncodedText(trim(trim(trim($matches[1]), '"\''))))];
+        $result = ['email' => '', 'name' => ''];
+        $addressArray = explode('@', $address);
+        $addressArrayLen = count($addressArray);
+        if ($addressArrayLen !== 2) {
+            return $result;
         }
-        return ['email' => strtolower(trim($address)), 'name' => ''];
+        $result['name'] = $addressArray[0];
+        $result['email'] = $address;
+        return $result;
     }
 
     /**
      * 
-     * @param string $addresses
+     * @param string $address
      * @return array
      */
-    private function parseEmailAddresses(string $addresses): array
+    private function parseEmailAddresses(array $address): array
+    {
+        $addressArray = (array)$address[0];
+        $result['name'] = $addressArray['mailbox'];
+        $result['email'] = $addressArray['mailbox'].'@'.$addressArray['host'];
+        return $result;
+    }
+
+    /**
+     * 
+     * @param string $email
+     * @return array
+     */
+    private function getBodyParts(string $email): array
     {
         $result = [];
-        $addresses = explode(',', $addresses);
-        foreach ($addresses as $address) {
-            $address = trim($address);
-            if (strlen($address) > 0) {
-                $result[] = $this->parseEmailAddress($address);
+        $emailSegment = explode('--', $email);
+        if(count($emailSegment) === 0) {
+            return $result;
+        }
+        $emailSegment = array_shift($emailSegment);
+        foreach ($emailSegment as $segments) {
+            $segment = explode(PHP_EOL, $segments);
+            if(count($segment) === 0) {
+                break;
+            }
+            foreach($segment as $value) {
+                $contentType = $this->getContentType($value);
+                $result['contentType'] = $contentType['contentType'];
+                $result['contentType'] = $contentType['charset'];
             }
         }
         return $result;
@@ -214,54 +163,26 @@ class EmailParser
 
     /**
      * 
-     * @param string $email
-     * @param string $parentContentType
+     * @param string $header
      * @return array
      */
-    private function getBodyParts(string $email, string $parentContentType = null, $level = 0): array
+    private function getContentType(string $header): array
     {
-        if ($parentContentType === null || $parentContentType === 'multipart/alternative' || $parentContentType === 'multipart/related' || $parentContentType === 'multipart/mixed' || $parentContentType === 'multipart/signed' || $parentContentType === 'multipart/report') {
-            // First 2 lines separate the headers from the body
-            $parts = explode("\r\n\r\n", $email, 2);
-            $headers = $this->parseHeaders(trim($parts[0]));
-            // When there is boundary
-            $contentTypeData = $this->getHeaderValueAndOptions($headers, 'Content-Type');
-            $contentType = $contentTypeData[0];
-            $boundary = isset($contentTypeData[1]['boundary']) ? $contentTypeData[1]['boundary'] : '';
-            if (strlen($boundary) > 0) {
-                $parts = explode('--' . $boundary, $email, 2);
-                $headers = $this->parseHeaders(trim($parts[0]));
-                $body = '--' . $boundary . (isset($parts[1]) ? trim($parts[1]) : '');
-            } else {
-                $body = isset($parts[1]) ? trim($parts[1]) : '';
-            }
-        } else {
-            $headers = [];
-            $body = trim($email);
+        $result = [];
+        $headerArray = explode(';', $header);
+        if(count($headerArray) !== 2) {
+            return $result;
         }
-
-        if (strlen($body) === 0) {
-            return [];
-        } else {
-            $contentTypeData = $this->getHeaderValueAndOptions($headers, 'Content-Type');
-            $contentType = $contentTypeData[0];
-            $boundary = isset($contentTypeData[1]['boundary']) ? $contentTypeData[1]['boundary'] : '';
-            if (strlen($boundary) > 0) {
-                $startIndex = strpos($body, '--' . $boundary) + strlen($boundary) + 2;
-                $endIndex = strpos($body, '--' . $body . '--') - 2;
-                $bodyParts = explode('--' . $boundary, substr($body, $startIndex, $endIndex - $startIndex));
-                $bodyParts = array_map('trim', $bodyParts);
-                $temp = [];
-                foreach ($bodyParts as $bodyPart) {
-                    $childBodyParts = $this->getBodyParts($bodyPart, $contentType, 1);
-                    $temp = array_merge($temp, $childBodyParts);
-                }
-                $bodyParts = $temp;
-            } else {
-                $bodyParts = [[$headers, trim($body), $level]];
-            }
-            return $bodyParts;
+        $charSet = $headerArray[1];
+        $charSet = str_replace('charset="', '', $charSet);
+        $charSet = str_replace('"', '', $charSet);
+        $result['charset'] = strtolower($charSet);
+        $contentType = explode(':', $headerArray[0]);
+        if(count($contentType) !== 2) {
+            return $result;
         }
+        $result['contentType'] = $contentType[1];
+        return $result;
     }
 
     /**

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -59,7 +59,22 @@ Content-Type: text/html; charset="UTF-8"
 
 --001a1137b910cdc17f405613f8f2b--';
         $result = $parser->parse($email);
-        $this->assertTrue($result['subject'] === 'Example email');
+        $this->assertSame('Example email', $result['subject']);
+        $this->assertSame('', $result['returnPath']);
+        $this->assertNull($result['priority']);
+        $this->assertFalse($result['deliveryDate']);
+        $this->assertSame(1514300508, $result['date']);
+        $this->assertSame('recipient@example.com', $result['to']['email']);
+        $this->assertSame('recipient', $result['to']['name']);
+        $this->assertSame('sender@example.com', $result['from']['email']);
+        $this->assertSame('sender', $result['from']['name']);
+        $this->assertSame('sender@example.com', $result['replyTo']['email']);
+        $this->assertSame('sender', $result['replyTo']['name']);
+        $this->assertSame('sender@example.com', $result['sender']['email']);
+        $this->assertSame('sender', $result['sender']['name']);
+        $this->assertSame('', $result['cc']['email']);
+        $this->assertSame('', $result['cc']['name']);
+        $this->assertSame('', $result['bcc']['email']);
+        $this->assertSame('', $result['bcc']['name']);
     }
-
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,7 +9,7 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-class EmailParserTestCase extends PHPUnit_Framework_TestCase
+class EmailParserTestCase extends PHPUnit\Framework\TestCase
 {
-    
+
 }


### PR DESCRIPTION
# Change log

- In stable PHPUnit version, it can be fine to remove the ```--configuration``` argument during running the ```phpunit``` command.
- Change the PHPUnit namespace the previous namespace is outdated.
- Use the ```assertSame``` to make the assertions readability.
- Add the ```ext-imap``` and ```ext-mbstring``` to check imap and mbstring extension are available in the php running environment.
- Oragnize the some methods in ```EmailParser``` class.
- Here is the [Travis-build](https://travis-ci.org/peter279k/email-parser) for testing email header parsing.

I just create the another branch named ```fix_bug_enhancement``` and I fix the getting value from parsed email message body.
However, I don't complete the get body message parts fully.
I think the previous get body part message method is complex and I try to let this easy.
We can discuss this if you have any problem about getting body part approach.

Thanks.
